### PR TITLE
fix: reCAPTCHA attribution and site-key guard

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -349,6 +349,9 @@ const ContactForm = () => {
           >
             {isLoading ? "Sending..." : "Send Message"}
           </button>
+          <p className="mt-3 text-xs text-black-500/60">
+            This site is protected by reCAPTCHA.
+          </p>
         </form>
       </div>
 


### PR DESCRIPTION
## Summary
- Add a minimal muted notice under the contact form submit button: "This site is protected by reCAPTCHA."
- Compensates for the hidden reCAPTCHA badge per Google’s attribution guidance.

## Test plan
- [ ] Contact form still submits as before
- [ ] Attribution appears under the submit button
- [ ] Attribution stays low-contrast and does not disrupt layout

Made with [Cursor](https://cursor.com)